### PR TITLE
feat: add get-explorer-url

### DIFF
--- a/src/components/app-explorer-link.tsx
+++ b/src/components/app-explorer-link.tsx
@@ -1,21 +1,21 @@
-import { getExplorerLink, GetExplorerLinkArgs } from 'gill'
-import { getSolanaClusterMoniker } from '@wallet-ui/react-gill'
 import { useSolana } from '@/components/solana/use-solana'
 import { ArrowUpRightFromSquare } from 'lucide-react'
 import { ReactNode } from 'react'
+import { ExplorerPath, getExplorerUrl } from '@/lib/get-explorer-url.ts'
 
 export function AppExplorerLink({
   className,
   label = '',
-  ...link
-}: GetExplorerLinkArgs & {
+  path,
+}: {
   className?: string
   label: ReactNode
+  path: ExplorerPath
 }) {
-  const { cluster } = useSolana()
+  const { explorer } = useSolana()
   return (
     <a
-      href={getExplorerLink({ ...link, cluster: getSolanaClusterMoniker(cluster.id) })}
+      href={getExplorerUrl({ ...explorer, path })}
       target="_blank"
       rel="noopener noreferrer"
       className={className ? className : `link font-mono inline-flex gap-1`}

--- a/src/components/solana/use-solana.tsx
+++ b/src/components/solana/use-solana.tsx
@@ -1,5 +1,6 @@
 import { useWalletUi } from '@wallet-ui/react'
 import { useWalletUiGill } from '@wallet-ui/react-gill'
+import { GetExplorerUrlProps } from '@/lib/get-explorer-url.ts'
 
 /**
  * Custom hook to abstract Wallet UI and related functionality from your app.
@@ -7,11 +8,16 @@ import { useWalletUiGill } from '@wallet-ui/react-gill'
  * This is a great place to add custom shared Solana logic or clients.
  */
 export function useSolana() {
-  const walletUi = useWalletUi()
+  const { cluster, ...walletUi } = useWalletUi()
   const client = useWalletUiGill()
-
+  const explorer: Omit<GetExplorerUrlProps, 'path'> = {
+    network: { id: cluster.id, endpoint: cluster.url },
+    provider: 'solana',
+  }
   return {
     ...walletUi,
     client,
+    cluster,
+    explorer,
   }
 }

--- a/src/components/toast-tx.tsx
+++ b/src/components/toast-tx.tsx
@@ -6,6 +6,6 @@ export function toastTx(signature?: string, title = 'Transaction sent') {
     return
   }
   toast(title, {
-    description: <AppExplorerLink transaction={signature} label="View Transaction" />,
+    description: <AppExplorerLink path={`/tx/${signature}`} label="View Transaction" />,
   })
 }

--- a/src/components/use-transaction-toast.tsx
+++ b/src/components/use-transaction-toast.tsx
@@ -4,7 +4,7 @@ import { AppExplorerLink } from './app-explorer-link.tsx'
 export function useTransactionToast() {
   return (signature: string) => {
     toast('Transaction sent', {
-      description: <AppExplorerLink transaction={signature} label="View Transaction" />,
+      description: <AppExplorerLink path={`/tx/${signature}`} label="View Transaction" />,
     })
   }
 }

--- a/src/features/account/account-feature-detail.tsx
+++ b/src/features/account/account-feature-detail.tsx
@@ -28,7 +28,7 @@ export default function AccountFeatureDetail() {
         title={<AccountUiBalance address={address} />}
         subtitle={
           <div className="my-4">
-            <AppExplorerLink address={address.toString()} label={ellipsify(address.toString())} />
+            <AppExplorerLink path={`/address/${address.toString()}`} label={ellipsify(address.toString())} />
           </div>
         }
       >

--- a/src/features/account/ui/account-ui-modal-receive.tsx
+++ b/src/features/account/ui/account-ui-modal-receive.tsx
@@ -17,7 +17,7 @@ export function AccountUiModalReceive({ address }: { address: Address }) {
     <AppModal title="Receive" submitLabel="Copy Address" submit={handleCopy}>
       <p>Receive assets by sending them to your public key:</p>
       <div className="flex items-center gap-2">
-        <AppExplorerLink address={address.toString()} label={address.toString()} />
+        <AppExplorerLink path={`/address/${address.toString()}`} label={address.toString()} />
       </div>
     </AppModal>
   )

--- a/src/features/account/ui/account-ui-tokens.tsx
+++ b/src/features/account/ui/account-ui-tokens.tsx
@@ -61,7 +61,10 @@ export function AccountUiTokens({ address }: { address: Address }) {
                     <TableCell>
                       <div className="flex space-x-2">
                         <span className="font-mono">
-                          <AppExplorerLink label={ellipsify(pubkey.toString())} address={pubkey.toString()} />
+                          <AppExplorerLink
+                            label={ellipsify(pubkey.toString())}
+                            path={`/address/${pubkey.toString()}`}
+                          />
                         </span>
                       </div>
                     </TableCell>
@@ -70,7 +73,7 @@ export function AccountUiTokens({ address }: { address: Address }) {
                         <span className="font-mono">
                           <AppExplorerLink
                             label={ellipsify(account.data.parsed.info.mint)}
-                            address={account.data.parsed.info.mint.toString()}
+                            path={`/address/${account.data.parsed.info.mint.toString()}`}
                           />
                         </span>
                       </div>

--- a/src/features/account/ui/account-ui-transactions.tsx
+++ b/src/features/account/ui/account-ui-transactions.tsx
@@ -49,10 +49,10 @@ export function AccountUiTransactions({ address }: { address: Address }) {
                 {items?.map((item) => (
                   <TableRow key={item.signature}>
                     <TableHead className="font-mono">
-                      <AppExplorerLink transaction={item.signature} label={ellipsify(item.signature, 8)} />
+                      <AppExplorerLink path={`/tx/${item.signature}`} label={ellipsify(item.signature, 8)} />
                     </TableHead>
                     <TableCell className="font-mono text-right">
-                      <AppExplorerLink block={item.slot.toString()} label={item.slot.toString()} />
+                      <AppExplorerLink path={`/block/${item.slot.toString()}`} label={item.slot.toString()} />
                     </TableCell>
                     <TableCell>{new Date(Number(item.blockTime ?? '0') * 1000).toISOString()}</TableCell>
                     <TableCell className="text-right">

--- a/src/features/playground/playground-feature-wallet-list-item.tsx
+++ b/src/features/playground/playground-feature-wallet-list-item.tsx
@@ -81,8 +81,8 @@ export function PlaygroundFeatureWalletListItem({ cluster, wallet }: { cluster: 
                 toast.success('Signing and sending transaction success', {
                   description: (
                     <AppExplorerLink
-                      transaction={signature}
                       label={<PlaygroundUiWalletAddress address={signature} len={10} />}
+                      path={`/tx/${signature}`}
                     />
                   ),
                 })
@@ -100,8 +100,8 @@ export function PlaygroundFeatureWalletListItem({ cluster, wallet }: { cluster: 
                 toast.success('Signing transaction success', {
                   description: (
                     <AppExplorerLink
-                      transaction={signature}
                       label={<PlaygroundUiWalletAddress address={signature} len={10} />}
+                      path={`/tx/${signature}`}
                     />
                   ),
                 })

--- a/src/lib/get-explorer-url.ts
+++ b/src/lib/get-explorer-url.ts
@@ -1,0 +1,62 @@
+import { SolanaClusterId } from '@wallet-ui/react'
+
+export type ExplorerPath = `/address/${string}` | `/block/${string}` | `/tx/${string}`
+export type ExplorerProvider = 'orb' | 'solana' | 'solscan'
+export const explorerProviders: ExplorerProvider[] = ['solana', 'solscan', 'orb'] as const
+
+export interface GetNetworkSuffixProps {
+  endpoint: string
+  id: SolanaClusterId
+}
+
+export interface GetExplorerUrlProps {
+  network: GetNetworkSuffixProps
+  path: ExplorerPath
+  provider: ExplorerProvider
+}
+
+export function getExplorerUrl({ network, path, provider }: GetExplorerUrlProps) {
+  if (!(path.startsWith('/address') || path.startsWith('/block') || path.startsWith('/tx'))) {
+    throw new Error('Invalid path. Must be /address, /block, or /tx.')
+  }
+  if (!explorerProviders.includes(provider)) {
+    throw new Error(`Invalid provider. Must be one of ${explorerProviders.join(', ')}.`)
+  }
+  const url = new URL(getExplorerBaseUrl(provider))
+  url.pathname = path
+  const params = getExplorerSuffix(network)
+  if (params.cluster.length) {
+    url.searchParams.set('cluster', params.cluster)
+  }
+  if (params.customUrl.length) {
+    url.searchParams.set('customUrl', params.customUrl)
+  }
+  return url.toString()
+}
+
+function getExplorerBaseUrl(provider: ExplorerProvider) {
+  switch (provider) {
+    case 'orb':
+      return 'https://orb.helius.dev'
+    case 'solscan':
+      return 'https://solscan.io'
+    default:
+      return 'https://explorer.solana.com'
+  }
+}
+
+function getExplorerSuffix(props: GetNetworkSuffixProps): {
+  cluster: string
+  customUrl: string
+} {
+  switch (props.id) {
+    case 'solana:devnet':
+      return { cluster: 'devnet', customUrl: '' }
+    case 'solana:localnet':
+      return { cluster: 'custom', customUrl: props.endpoint }
+    case 'solana:testnet':
+      return { cluster: 'testnet', customUrl: '' }
+    default:
+      return { cluster: '', customUrl: '' }
+  }
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces `getExplorerUrl` utility for generating Solana explorer URLs, updating components to use this new function.
> 
>   - **Behavior**:
>     - Replaces `getExplorerLink` with `getExplorerUrl` in `AppExplorerLink` component.
>     - Updates `AppExplorerLink` to use `path` prop instead of specific transaction or address props.
>     - Updates components like `toastTx`, `useTransactionToast`, `AccountFeatureDetail`, `AccountUiModalReceive`, `AccountUiTokens`, `AccountUiTransactions`, and `PlaygroundFeatureWalletListItem` to use `path` prop with `AppExplorerLink`.
>   - **Utilities**:
>     - Adds `get-explorer-url.ts` with `getExplorerUrl` function to generate URLs for Solana explorers.
>     - Defines `ExplorerPath` and `ExplorerProvider` types in `get-explorer-url.ts`.
>   - **Hooks**:
>     - Updates `useSolana` hook to include `explorer` object with network and provider details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=wallet-ui%2Fwallet-ui-playground&utm_source=github&utm_medium=referral)<sup> for 8e186c571132dd334303eacff3163488c71fedde. You can [customize](https://app.ellipsis.dev/wallet-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->